### PR TITLE
フード一覧ページにスタイルをあてる

### DIFF
--- a/frontend/src/components/FoodWrapper.jsx
+++ b/frontend/src/components/FoodWrapper.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// components
+import { SubText } from './StyledText';
+
+// constants
+import { COLORS } from '../style_constants';
+
+const Wrapper = styled.div`
+  display: flex;
+  width: 450px;
+  height: 180px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: ${COLORS.BORDER};
+  border-image: initial;
+  cursor: pointer;
+`;
+
+const FoodDetail = styled.div`
+  padding: 24px 16px;
+  width: 250px;
+`;
+
+const DescriptionWrapper = styled.div`
+  height: 75px;
+`
+
+const PriceWrapper = styled.div`
+  margin-top: 16px;
+`
+
+const FoodImageNode = styled.img`
+  width: 250px;
+`;
+
+export const FoodWrapper = ({
+  food,
+  onClickFoodWrapper,
+  imageUrl,
+}) => (
+  <Wrapper onClick={() => onClickFoodWrapper(food)}>
+    <FoodDetail>
+      {food.name}
+      <DescriptionWrapper>
+        <SubText>
+          {food.description}
+        </SubText>
+      </DescriptionWrapper>
+      <PriceWrapper>
+        ¥{food.price}
+      </PriceWrapper>
+    </FoodDetail>
+    <FoodImageNode src={imageUrl} />
+  </Wrapper>
+)

--- a/frontend/src/components/Icons/index.js
+++ b/frontend/src/components/Icons/index.js
@@ -1,0 +1,2 @@
+export { default as LocalMallIcon } from '@material-ui/icons/LocalMall';
+export { default as QueryBuilderIcon } from '@material-ui/icons/QueryBuilder';

--- a/frontend/src/components/StyledText.jsx
+++ b/frontend/src/components/StyledText.jsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+import { COLORS, FONT_SIZE } from '../style_constants';
+
+export const SubText = styled.p`
+  color: ${COLORS.SUB_TEXT};
+  font-size: ${FONT_SIZE.BODY2};
+`;

--- a/frontend/src/containers/Foods.jsx
+++ b/frontend/src/containers/Foods.jsx
@@ -1,4 +1,11 @@
 import React, { Fragment, useEffect, useReducer } from 'react';
+import styled from 'styled-components';
+import { Link } from "react-router-dom";
+
+// components
+import { LocalMallIcon } from '../components/Icons';
+import { FoodWrapper } from '../components/FoodWrapper';
+import Skeleton from '@material-ui/lab/Skeleton';
 
 // reducers
 import {
@@ -10,8 +17,42 @@ import {
 // apis
 import { fetchFoods } from '../apis/foods';
 
+// images
+import MainLogo from '../images/logo.png';
+import FoodImage from '../images/food-image.jpg';
+
 // constants
 import { REQUEST_STATE } from '../constants';
+import { COLORS } from '../style_constants';
+
+const HeaderWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 32px;
+`;
+
+const BagIconWrapper = styled.div`
+  padding-top: 24px;
+`;
+
+const ColoredBagIcon = styled(LocalMallIcon)`
+  color: ${COLORS.MAIN};
+`;
+
+const MainLogoImage = styled.img`
+  height: 90px;
+`
+
+const FoodsList = styled.div`
+  display: flex;
+  justify-content: space-around;
+  flex-wrap: wrap;
+  margin-bottom: 50px;
+`;
+
+const ItemWrapper = styled.div`
+  margin: 16px;
+`;
 
 export const Foods = ({
   match
@@ -33,20 +74,40 @@ export const Foods = ({
 
   return (
     <Fragment>
-      {
-        foodsState.fetchState === REQUEST_STATE.LOADING ?
-          <Fragment>
-            <p>
-              ロード中...
-            </p>
-          </Fragment>
-          :
-          foodsState.foodsList.map(food =>
-            <div key={food.id}>
-              {food.name}
-            </div>
-          )
-      }
+      <HeaderWrapper>
+        <Link to="/restaurants">
+          <MainLogoImage src={MainLogo} alt="main logo" />
+        </Link>
+        <BagIconWrapper>
+          <Link to="/orders">
+            <ColoredBagIcon fontSize="large" />
+          </Link>
+        </BagIconWrapper>
+      </HeaderWrapper>
+      <FoodsList>
+        {
+          foodsState.fetchState === REQUEST_STATE.LOADING ?
+            <Fragment>
+              {
+                [...Array(12).keys()].map(i =>
+                  <ItemWrapper key={i}>
+                    <Skeleton key={i} variant="rect" width={450} height={180} />
+                  </ItemWrapper>
+                )
+              }
+            </Fragment>
+            :
+            foodsState.foodsList.map(food =>
+              <ItemWrapper key={food.id}>
+                <FoodWrapper
+                  food={food}
+                  onClickFoodWrapper={(food) => console.log(food)}
+                  imageUrl={FoodImage}
+                />
+              </ItemWrapper>
+            )
+        }
+      </FoodsList>
     </Fragment>
   )
 }


### PR DESCRIPTION
レストラン一覧との違いはidを渡したところだけだったがスタイルの量が多すぎる。
別フォルダでスタイルのみを管理できたらかなりいいと思った。
pfでは実行したい。